### PR TITLE
add bindEffO

### DIFF
--- a/src/Control/Observable.js
+++ b/src/Control/Observable.js
@@ -586,3 +586,13 @@ exports._bind = function (observable) {
     return observable.flatMap(fn);
   };
 };
+
+exports.bindEffO = function (observable) {
+  return function (effFn) {
+    return function () {
+      return observable.flatMap(function (x) {
+        return effFn(x)();
+      });
+    }
+  };
+};

--- a/src/Control/Observable.purs
+++ b/src/Control/Observable.purs
@@ -34,6 +34,7 @@ module Control.Observable
   , distinct
   , sampleOn
   , bufferOn
+  , bindEffO
   ) where
 
 import Prelude
@@ -65,6 +66,7 @@ type EffO e a = Eff (observable :: OBSERVABLE | e) a
 
 foreign import schedule :: forall e. EffO e Unit -> EffO e Unit
 foreign import _bind :: forall a b. Observable a -> (a -> Observable b) -> Observable b
+foreign import bindEffO :: forall e a b. Observable a -> (a -> EffO e (Observable b)) -> EffO e (Observable b)
 
 -- | An `Observable` represents a finite stream of asynchronous values.
 -- | You can attach `Observer`s to it to react to events such as new values,


### PR DESCRIPTION
Fixes #1 

This was what I thought it might look like in usage:

``` purescript
results <- liftEff $ (requests <|> timer) `bindEffO` \request ->
    liftAff $ runTorscraper torscraperPath request
```

[source](https://github.com/justinwoo/simple-rpc-telegram-bot/blob/d470daf217aeea66b970b14e84fe937dd35609f6/src/Main.purs#L117-L118)
